### PR TITLE
fix error, CREATE_FAILED: QueryLambdaFunction (AWS::Lambda::Function)

### DIFF
--- a/example-queries/README.md
+++ b/example-queries/README.md
@@ -1,0 +1,95 @@
+# Claude prompts
+
+## For generating SQL queries in json format
+
+  ```` 
+  ```
+  {
+    "query": "SELECT avg(Min_Charge), avg(Max_Charge) FROM 'https://beta.payless.health/data/131624096_mount-sinai-hospital_standardcharges-subset.parquet' WHERE description LIKE '%STELARA%';"
+  }
+  ```
+
+  please rewrite this exact SQL query inside of a json file to select the column Code_type rows with a value of of `Charge_Code` and the `Primary_Code` values of `18480415, 18480213, 18480214`, and retrieve the `description` column, the `Min_Charge`, `Max_Charge`, `Product_Name_Minimum`, `Product_Name_Maximum` column values
+  ````
+
+## Creating a JSX template
+```` 
+```
+Code_type	Primary_Code	description	Min_Charge	Max_Charge	Product_Name_Maximum	Product_Name_Minimum
+Charge_Code	18480415	STELARA INJ 130MG VL BU1MG	1	36.19	Small Group	Small Group
+Charge_Code	18480213	STELARA SYR 45 BU1MG	111.83	454.4	Affinity Medicaid, HARP, Essential Plans 3-4, CHIP	Affinity Medicaid, HARP, Essential Plans 3-4, CHIP
+Charge_Code	18480214	STELARA SYR 90 BU1MG	111.83	497.56	Indemnity	Indemnity
+```
+
+please create a JSX template for incremental static regeneration that queries an API endpoint on AWS lambda to retrieve data corresponding to the `Code_type` of `Charge_Code` and the `Primary_Code` values of `18480415, 18480213, 18480214`, and has a few sentences like the below. please also include one sentence about the product description and the primary codes, alongside the minimum and maximum charges and the insurance product names corresponding to it:
+
+```
+{insurance product name} has the highest price of {amount} for the {row description} compared to the {number of} insurance products at this hospital. This price is {XXX} higher from the median of {xx} across insurance products. 
+
+{insurance product name} has the lowest price of {amount} for the {row description} compared to the {number of} insurance products at this hospital. This price is {XXX} lower from the median of {xx} of {description} across insurance products.
+```
+
+please query the following API endpoint using the following example:
+
+```
+curl --location --request POST 'https://REDACTED.execute-api.us-east-1.amazonaws.com/prd/v1/query' \
+--header 'x-api-key: REDACTED' \
+--header 'Content-Type: application/json' \
+--data-raw '{
+    "query": "SELECT Min_Charge, Product_Name_Minimum FROM '\''https://beta.payless.health/data/131624096_mount-sinai-hospital_standardcharges-subset.parquet'\'' WHERE Code_type = '\''Charge_Code'\'' AND Primary_Code IN (18480415, 18480213, 18480214);"
+}'
+```
+````
+
+Response:
+
+```
+import { useState, useEffect } from 'react';
+
+export default function Pricing() {
+
+  const [data, setData] = useState(null);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      const response = await fetch('https://REDACTED.execute-api.us-east-1.amazonaws.com/prd/v1/query', {
+        method: 'POST',
+        headers: {
+          'x-api-key': 'REDACTED',
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify({
+          query: "SELECT Min_Charge, Max_Charge, Product_Name_Minimum, Product_Name_Maximum, description FROM 'https://beta.payless.health/data/131624096_mount-sinai-hospital_standardcharges-subset.parquet' WHERE Code_type = 'Charge_Code' AND Primary_Code IN (18480415, 18480213, 18480214);" 
+        })
+      });
+      const json = await response.json();
+      setData(json);
+    };
+
+    fetchData();
+  }, []);
+
+  return (
+    <div>
+      {data && 
+        <>
+          <p>
+            {data[0].Product_Name_Minimum} has the lowest price of {data[0].Min_Charge} for the {data[0].description} compared to the {data.length} insurance products at this hospital. This price is {data[0].Max_Charge - data[0].Min_Charge} lower from the median of {calculateMedian(data)} for {data[0].description} across insurance products.
+          </p>
+          
+          <p>
+            {data[1].Product_Name_Maximum} has the highest price of {data[1].Max_Charge} for the {data[1].description} compared to the {data.length} insurance products at this hospital. This price is {data[1].Max_Charge - data[1].Min_Charge} higher from the median of {calculateMedian(data)} for {data[1].description} across insurance products.  
+          </p>
+        </>
+      }
+    </div>
+  );
+  
+  function calculateMedian(data) {
+    const charges = data.map(item => item.Min_Charge);
+    const mid = Math.floor(charges.length / 2);
+    charges.sort((a, b) => a - b);
+    return charges.length % 2 !== 0 ? charges[mid] : (charges[mid - 1] + charges[mid]) / 2; 
+  }
+}
+```

--- a/example-queries/humira-query.sh
+++ b/example-queries/humira-query.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+<<'###BLOCK-COMMENT'
+Claude prompt:
+
+--data-raw '{
+    "query": "SELECT avg(c_acctbal) FROM '\''https://shell.duckdb.org/data/tpch/0_01/parquet/customer.parquet'\'';"
+}'
+
+please rewrite this exact command line flag with the properly escaped SQL query (using '\'' to escape the single quotes) with the duckdb dialect to select all rows where the column `description` contains the string `stelara`, from the parquet file containing the duckdb database at https://beta.payless.health/data/131624096_mount-sinai-hospital_standardcharges-subset.parquet
+###BLOCK-COMMENT
+
+curl --location --request POST 'https://REDACTED.execute-api.us-east-1.amazonaws.com/prd/v1/query' \
+--header 'x-api-key: REDACTED' \
+--header 'Content-Type: application/json' \
+--data-raw '{
+    "query": "SELECT avg(Min_Charge), avg(Max_Charge) FROM '\''https://beta.payless.health/data/131624096_mount-sinai-hospital_standardcharges-subset.parquet'\'' WHERE description LIKE '\''%HUMIRA%'\'';"
+}'
+

--- a/example-queries/json-queries/humira-string-query.json
+++ b/example-queries/json-queries/humira-string-query.json
@@ -1,0 +1,3 @@
+{
+  "query": "SELECT avg(Min_Charge), avg(Max_Charge) FROM 'https://beta.payless.health/data/131624096_mount-sinai-hospital_standardcharges-subset.parquet' WHERE description LIKE '%HUMIRA%';"
+}

--- a/example-queries/json-queries/stelara-codes-query.json
+++ b/example-queries/json-queries/stelara-codes-query.json
@@ -1,0 +1,3 @@
+{
+  "query": "SELECT description, Min_Charge, Max_Charge, Product_Name_Minimum, Product_Name_Maximum FROM 'https://beta.payless.health/data/131624096_mount-sinai-hospital_standardcharges-subset.parquet' WHERE Code_type = 'Charge_Code' AND Primary_Code IN (18480415, 18480213, 18480214);" 
+}

--- a/example-queries/json-queries/stelara-string-query.json
+++ b/example-queries/json-queries/stelara-string-query.json
@@ -1,0 +1,3 @@
+{
+  "query": "SELECT avg(Min_Charge), avg(Max_Charge) FROM 'https://beta.payless.health/data/131624096_mount-sinai-hospital_standardcharges-subset.parquet' WHERE description LIKE '%STELARA%';"
+}

--- a/example-queries/minimum-charge-query.sh
+++ b/example-queries/minimum-charge-query.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+<<'###BLOCK-COMMENT'
+###BLOCK-COMMENT
+
+curl --location --request POST 'https://REDACTED.execute-api.us-east-1.amazonaws.com/prd/v1/query' \
+--header 'x-api-key: REDACTED' \
+--header 'Content-Type: application/json' \
+--data-raw '{
+    "query": "SELECT avg(Min_Charge) FROM '\''https://beta.payless.health/data/131624096_mount-sinai-hospital_standardcharges-subset.parquet'\'';"
+}'

--- a/example-queries/query.sh
+++ b/example-queries/query.sh
@@ -1,9 +1,8 @@
 #!/bin/bash
 # Need to replace REDACTED with the API key and URL 
+# Usage: 
 
 curl --location --request POST 'https://REDACTED.execute-api.us-east-1.amazonaws.com/prd/v1/query' \
 --header 'x-api-key: REDACTED' \
 --header 'Content-Type: application/json' \
---data-raw '{
-    "query": "SELECT avg(Min_Charge) FROM '\''https://beta.payless.health/data/131624096_mount-sinai-hospital_standardcharges-subset.parquet'\'';"
-}'
+-d @$1

--- a/example-queries/query.sh
+++ b/example-queries/query.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 # Need to replace REDACTED with the API key and URL 
-# Usage: 
+# Usage:  me@laptop   ~/projects/serverless-duckdb/example-queries     main    ./query.sh ./json-queries/stelara-codes-query.json 
+# Returns: [{"description":"STELARA INJ 130MG VL BU1MG","Min_Charge":1,"Max_Charge":36.189998626708984,"Product_Name_Minimum":"Small Group","Product_Name_Maximum":"Small Group"},{"description":"STELARA SYR 45 BU1MG","Min_Charge":111.83000183105469,"Max_Charge":454.3999938964844,"Product_Name_Minimum":"Affinity Medicaid, HARP, Essential Plans 3-4, CHIP","Product_Name_Maximum":"Affinity Medicaid, HARP, Essential Plans 3-4, CHIP"},{"description":"STELARA SYR 90 BU1MG","Min_Charge":111.83000183105469,"Max_Charge":497.55999755859375,"Product_Name_Minimum":"Indemnity","Product_Name_Maximum":"Indemnity"}]%  
 
 curl --location --request POST 'https://REDACTED.execute-api.us-east-1.amazonaws.com/prd/v1/query' \
 --header 'x-api-key: REDACTED' \

--- a/example-queries/stelara-query.sh
+++ b/example-queries/stelara-query.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+<<'###BLOCK-COMMENT'
+Claude prompt:
+
+--data-raw '{
+    "query": "SELECT avg(c_acctbal) FROM '\''https://shell.duckdb.org/data/tpch/0_01/parquet/customer.parquet'\'';"
+}'
+
+please rewrite this exact command line flag with the properly escaped SQL query (using '\'' to escape the single quotes) with the duckdb dialect to select all rows where the column `description` contains the string `stelara`, from the parquet file containing the duckdb database at https://beta.payless.health/data/131624096_mount-sinai-hospital_standardcharges-subset.parquet
+###BLOCK-COMMENT
+
+curl --location --request POST 'https://REDACTED.execute-api.us-east-1.amazonaws.com/prd/v1/query' \
+--header 'x-api-key: REDACTED' \
+--header 'Content-Type: application/json' \
+--data-raw '{
+    "query": "SELECT avg(Min_Charge), avg(Max_Charge) FROM '\''https://beta.payless.health/data/131624096_mount-sinai-hospital_standardcharges-subset.parquet'\'' WHERE description LIKE '\''%STELARA%'\'';"
+}'

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,7 @@
     "": {
       "name": "serverless-duckdb",
       "version": "0.1.0",
-      "license": "UNLICENSED",
+      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.12.5",
         "aws-embedded-metrics": "^4.0.0",

--- a/serverless.yml
+++ b/serverless.yml
@@ -1,3 +1,5 @@
+org: jaanli
+app: serverless-duckdb
 service: serverless-duckdb
 
 frameworkVersion: '3'
@@ -40,7 +42,7 @@ functions:
 
   query:
     handler: src/functions/query.handler
-    memorySize: 10240
+    memorySize: 3008
     timeout: 30
     # Enable this for arm64 support
     # architecture: arm64


### PR DESCRIPTION
Fixes the following error: "Resource handler returned message: "MemorySize value failed to satisfy constraint: Member must have value less than or equal to 3008 (Service: Lambda, Status Code: 400..."

```
me@laptop   ~/projects  cd serverless-duckdb          6916  13:25:02 
 me@laptop   ~/projects/serverless-duckdb     main   sls deploy
Running "serverless" from node_modules

Deploying serverless-duckdb to stage prd (us-east-1, "one-fact-foundation" provider)

✖ Stack serverless-duckdb-prd failed to deploy (69s)
Environment: darwin, node 20.5.0, framework 3.27.0 (local) 3.16.0v (global), plugin 6.2.3, SDK 4.3.2
Credentials: Serverless Dashboard, "one-fact-foundation" provider (https://app.serverless.com/jaanli/apps/serverless-duckdb/serverless-duckdb/prd/us-east-1/providers)
Docs:        docs.serverless.com
Support:     forum.serverless.com
Bugs:        github.com/serverless/serverless/issues

Error:
CREATE_FAILED: QueryLambdaFunction (AWS::Lambda::Function)
Resource handler returned message: "'MemorySize' value failed to satisfy constraint: Member must have value less than or equal to 3008 (Service: Lambda, Status Code: 400, Request ID: 1daa3d08-4483-4f5d-8624-4f0b8e1ee7c6)" (RequestToken: d16dfc84-3aaa-9b6c-6a73-d9bae400b02f, HandlerErrorCode: InvalidRequest)

View the full error: https://us-east-1.console.aws.amazon.com/cloudformation/home?region=us-east-1#/stack/detail?stackId=arn%3Aaws%3Acloudformation%3Aus-east-1%3A339418863508%3Astack%2Fserverless-duckdb-prd%2Fdbb32250-3c59-11ee-90b7-0a09729e3ad7
```

Thank you for making this, it is an unbelievable help! It will help us @onefact build https://beta.payless.health/examples/mount-sinai.html so that every hospitals' price can be generated into a story (using the AWS lambda function :)